### PR TITLE
Update to Node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,6 @@ RUN echo "$LANG -- $LANGUAGE -- $LC_ALL" \
     && git --version \
     && mvn --version \
     && java --version \
-    && javac --version
+    && javac --version \
+    && node --version \
+    && npm --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM maven:3-eclipse-temurin-17
 
 MAINTAINER Stephan Krusche <krusche@in.tum.de>
 
-RUN apt-get update && apt-get install -y locales
+RUN apt-get update && apt-get upgrade -y && apt-get install -y locales
 
 # Set the locale
 RUN locale-gen en_US.UTF-8
@@ -12,7 +12,7 @@ ENV LC_ALL en_US.UTF-8
 
 RUN apt-get update && apt-get install -y \
     gnupg \
- && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+ && curl -sL https://deb.nodesource.com/setup_18.x | bash - \
  && apt-get update && apt-get install -y \
     nodejs \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
We recently updated Artemis to use node 18, so this should be included in this docker image.