### PR TITLE
Install Java 17 additionally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
+# Also install Java 17 (needed for running PE templates)
 RUN apt-get update && apt-get install -y \
-    gnupg \
+    gnupg openjdk-17-jdk \
  && curl -sL https://deb.nodesource.com/setup_20.x | bash - \
  && apt-get update && apt-get install -y \
     nodejs \


### PR DESCRIPTION
The new version of the `ProgrammingExerciseTemplateIntegrationTest` runs the programming template with a local Java 17 version. Therefore we install Java 17 as well as Java 21 in this image.